### PR TITLE
feat: added Linux category

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -132,6 +132,7 @@ const config = {
     ],
   },
   linux: {
+    category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
   },


### PR DESCRIPTION
fixed:
  • application Linux category is set to default "Utility"  reason=linux.category is not set and cannot map from macOS docs=https://www.electron.build/configuration/linux